### PR TITLE
fix: set client from $apollo correctly in mutateWithErrorHandling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './ApolloErrorProcessor';
+export * from './handleApolloError';
 export * from './mutation';
 export * from './query';
 export * from './subscription';

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -90,7 +90,11 @@ export async function mutateWithErrorHandling<
   client?: ApolloMutationClient<TResult, TVariables>,
 ): Promise<MutationResult<TResult>> {
   const mutate =
-    client === undefined ? app.$apollo : typeof client === 'function' ? client : client.mutate.bind(client);
+    client === undefined
+      ? app.$apollo.mutate.bind(app.$apollo)
+      : typeof client === 'function'
+      ? client
+      : client.mutate.bind(client);
 
   try {
     const result = await mutate({


### PR DESCRIPTION
Resolves error `mutate is not a function` when calling a mutation function without passing a `client`.